### PR TITLE
Update plugin.yml

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,10 +1,10 @@
 name: Slapper
 author: IcyEndymion004
-version: 1.6.1
+version: 1.6.2
 description: Slapper, the NPC plugin for PocketMine-MP
 main: slapper\Main
 api: 3.0.0
-mcpe-protocol: [361, 388, 389, 390, 407, 408, 448, 465, 475]
+mcpe-protocol: [408, 448, 465, 475]
 website: https://github.com/jojoe77777/Slapper
 
 commands:


### PR DESCRIPTION
Most Minecraft protocol version are not more supported because API 4.0 is on May 2022 the new Version and 3.0 are not more a Currently Version